### PR TITLE
Feature/coraza setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DOMAIN=ft-transcendence.app
+SCHEME=https
+
+PROD=0
+
+DEV_HTTP_PORT=8080
+DEV_HTTPS_PORT=8443

--- a/caddy-coraza/Caddyfile.template
+++ b/caddy-coraza/Caddyfile.template
@@ -2,14 +2,25 @@
 	skip_install_trust # caddy is running as non-root, therefore CA trust installation won't work (and isn't needed anyway inside the container)
 	http_port 8080
 	https_port 8443
+	order coraza_waf first
 }
 
 (static) {
+	coraza_waf {
+		load_owasp_crs
+		directives `
+			Include @coraza.conf-recommended
+			Include @crs-setup.conf.example
+			Include @owasp_crs/*.conf
+			SecRuleEngine on
+		`
+	}
 	root * /static
 	file_server
 }
 
 # Below variables will be replaced inside caddy-wrapper.sh
+# Default is just http://localhost, so ideal for development (no automatic tls certificate generation)
 $SCHEME://$DOMAIN {
 	import static
 }

--- a/caddy-coraza/Caddyfile.template
+++ b/caddy-coraza/Caddyfile.template
@@ -6,6 +6,9 @@
 }
 
 (static) {
+	# The following tests should return 403 Forbidden and the Caddy log should show the block event
+	# - `curl localhost?foo=/bin/bash`
+	# - `curl localhost -d /bin/bash`
 	coraza_waf {
 		load_owasp_crs
 		directives `

--- a/caddy-coraza/Dockerfile
+++ b/caddy-coraza/Dockerfile
@@ -23,9 +23,12 @@ COPY                ./caddy-wrapper.sh /caddy-wrapper.sh
 COPY                ./Caddyfile.template /etc/caddy/Caddyfile.template
 
 # ensure directories and correct owners
-RUN rm -rf /data /config /srv && \
-	mkdir /data /config /srv && \
+RUN rm -rf            /data /config /srv /static && \
+	mkdir             /data /config /srv         && \
 	chown caddy:caddy /data /config /srv
+
+# Bind mount would be better, but gives weird error: "open /static: stale NFS file handle"
+COPY --chown=caddy:caddy ./static /static
 
 WORKDIR /srv
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,8 +7,8 @@ services:
     container_name: caddy-coraza
     restart: unless-stopped
     ports:
-      - "80:8080"
-      - "443:8443"
+      - "${DEV_HTTP_PORT:-80}:8080"
+      - "${DEV_HTTPS_PORT:-443}:8443"
     environment:
       DOMAIN: ${DOMAIN:-}
       SCHEME: ${SCHEME:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,6 @@ services:
       context: "./caddy-coraza/"
     container_name: caddy-coraza
     restart: unless-stopped
-    volumes:
-      - "./caddy-coraza/static/:/static/"
     ports:
       - "80:8080"
       - "443:8443"

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,5 @@ services:
     develop:
       watch: # will reload caddy when changing Caddyfile.template in the host system
         - path: ./caddy-coraza/Caddyfile.template
-          action: sync+exec
+          action: rebuild
           target: /etc/caddy/Caddyfile.template
-          exec: # this requires docker compose 2.32.2 or later
-            command: /caddy-wrapper.sh reload


### PR DESCRIPTION
Merge #4 first, then this one.
Enables the coraza WAF functionality with the OWASP CRS (Core Rule Set), which works surprising well, as seen with the test cases provided in the comments inside the Caddyfile.template.